### PR TITLE
update copyQrCodeImage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,9 +29,11 @@ function App() {
       return;
     }
     html2canvas(qrCodeRef.current).then((canvas) => {
-      const qrCodeImage = canvas.toDataURL("image/png");
-      navigator.clipboard.writeText(qrCodeImage).then(() => {
-        toast.success("QR Code image copied to clipboard.");
+      canvas.toBlob((blob) => {
+        const item = new ClipboardItem({ "image/png": blob });
+        navigator.clipboard.write([item]).then(() => {
+          toast.success("QR Code image copied to clipboard.");
+        });
       });
     });
   };


### PR DESCRIPTION
## Description of Changes

This pull request addresses the issue of copying the QR Code image to the clipboard in a way that can be pasted into applications that accept images.

Previously, the `copyQrCodeImage` function was copying a Base64 representation of the image to the clipboard. However, this resulted in a long string of digits and characters being copied, which couldn't be directly pasted as an image into most applications.

This pull request modifies the `copyQrCodeImage` function to use the `navigator.clipboard.write` method with a `ClipboardItem` object instead of the `navigator.clipboard.writeText` method. This will allow the image to be copied to the clipboard in a format that can be directly pasted into applications that accept images.

### Key Changes

- Modified the `copyQrCodeImage` function to convert the canvas to a Blob (binary representation of the image), create a new `ClipboardItem` object using that Blob, and then use `navigator.clipboard.write` to write the `ClipboardItem` to the clipboard.

### Note
Please be aware that the clipboard API may not be supported in all browsers and may require user permissions to access the clipboard. It's also required to be running in a secure context (like HTTPS).
